### PR TITLE
remove "get prefixes"

### DIFF
--- a/lib/localTripleStore.js
+++ b/lib/localTripleStore.js
@@ -14,12 +14,9 @@ module.exports = class LocalTripleStore{
     return {
       next: () => ({ value: data[++index], done: !(index in data) })
     };
-  };
+  }
   get size(){
     return this.triples.length;
-  }
-  get prefixes(){
-    return this.prefixes;
   }
   setPrefixes(prefixes){
     this.prefixes = prefixes;
@@ -48,4 +45,4 @@ module.exports = class LocalTripleStore{
     });
     return rdf;
   }
-}
+};


### PR DESCRIPTION
Currently the module throw the following exception:
>  Cannot set property prefixes of #<LocalTripleStore> which has only a getter

Actually, a so-written getter has no reason to stay there. Removing it will give the same expected behaviour... without breaking the module! :)