### PR TITLE
Add the ability to create a define statement

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -8,6 +8,7 @@ const Triple = require('./triple');
 module.exports = class Client {
   constructor(endpoint){
     this.defaultPrefixes = DEFAULT_PREFIXES;
+    this.defaultDefines = {};
     this.endpoint = endpoint;
     this.triples = [];
     this.setOptions();
@@ -292,6 +293,11 @@ module.exports = class Client {
     this.setDefaultPrefixes(joinedPrefixes);
     return this.defaultPrefixes;
   }
+  addDefines(defines){
+    let joinedDefines = Object.assign({}, defines);
+    this.setDefaultDefines(joinedDefines);
+    return this.defaultDefines;
+  }
 
   static composePrefixes(prefixes) {
     let prefix, iri;
@@ -304,11 +310,22 @@ module.exports = class Client {
     return prefixesString;
   }
 
-  setOptions(format = "application/ld+json", prefixes = {}, graph = ""){
+  static composeDefines(defines) {
+        let define, literal;
+        let defineString = "";
+        for (define in defines) {
+          literal = defines[define];
+          defineString += `define ${define} '${literal}'
+          `;
+        }
+        return defineString;
+  }
+
+  setOptions(format = "application/ld+json", prefixes = {}, graph = "", defines = {}){
     this.setDefaultFormat(format);
     this.addPrefixes(prefixes);
     this.setDefaultGraph(graph);
-
+    this.addDefines(defines);
   }
 
   setQueryGraph(graph){
@@ -320,6 +337,9 @@ module.exports = class Client {
   setQueryPrefixes(prefixes){
     this.queryPrefixes = prefixes;
   }
+  setQueryDefines(defines){
+    this.queryDefines = defines;
+  }
   setQueryMaxrows(rows){
     this.queryMaxrows = rows;
   }
@@ -328,6 +348,9 @@ module.exports = class Client {
   }
   setDefaultPrefixes(prefixes){
     this.defaultPrefixes = prefixes;
+  }
+  setDefaultDefines(defines){
+    this.defaultDefines = defines;
   }
   setDefaultGraph(graph){
     this.defaultGraph = graph;
@@ -358,7 +381,9 @@ module.exports = class Client {
 
     let body = {};
     let prefixes = this._calculateQueryPrefixes();
+    let defines = this._calculateQueryDefines();
     body.query = `
+      ${Client.composeDefines(defines)}
       ${Client.composePrefixes(prefixes)}
       ${query}
     `;
@@ -378,6 +403,9 @@ module.exports = class Client {
   _calculateQueryPrefixes(){
     return Object.assign({}, DEFAULT_PREFIXES, this.defaultPrefixes, this.queryPrefixes);
   }
+  _calculateQueryDefines(){
+    return Object.assign({}, this.defaultDefines, this.queryDefines);
+  }
   _calculateQueryFormat(){
     return (this.queryFormat) ? this.queryFormat : (this.defaultFormat) ? this.defaultFormat : "application/ld+json";
   }
@@ -395,6 +423,7 @@ module.exports = class Client {
     this.queryGraph = null;
     this.queryFormat = null;
     this.queryPrefixes = null;
+    this.queryDefines = null;
     this.queryMaxrows = null;
     this.namedGraphUri = null;
     this.methodName = "query";


### PR DESCRIPTION
I did not update the readme, but this allows for the 'define' statements that are required for reasoning in virtuoso. This is based on:
http://vos.openlinksw.com/owiki/wiki/VOS/VirtSPARQLReasoningTutorial#Step%206.%3A%20SPARQL%20Inference%20Queries

I utilized your basic structure and have tested the following:
`setDefaultDefines({...<defines object>...});`
`...addDefines({...<defines object>...});`
`...setOptions(<encoding type>, <prefixes object>, <IRI>, {...<defines object>...});`

The defines object looks just like the prefixes object. From the example above this would be:
`{
   "input:inference":  "urn:owl:inference:rules:tests"
}`